### PR TITLE
Fix for Android 14 (SDK 34)

### DIFF
--- a/library/src/main/kotlin/io/beyondwords/player/MediaButtonReceiver.kt
+++ b/library/src/main/kotlin/io/beyondwords/player/MediaButtonReceiver.kt
@@ -30,7 +30,11 @@ open class MediaButtonReceiver constructor(private val mediaSessionId: Int) :
             intent.putExtra(Intent.EXTRA_KEY_EVENT, KeyEvent(KeyEvent.ACTION_DOWN, keyCode))
             intent.putExtra(EXTRA_MEDIA_SESSION_ID, mediaSessionId)
             val requestCode = mediaSessionId * 1000 + keyCode // keyCode is a 3 digit number
-            val flags = if (Build.VERSION.SDK_INT >= 31) PendingIntent.FLAG_IMMUTABLE else 0
+            val flags = when {
+                Build.VERSION.SDK_INT >= 34 -> PendingIntent.FLAG_MUTABLE or PendingIntent.FLAG_ALLOW_UNSAFE_IMPLICIT_INTENT
+                Build.VERSION.SDK_INT >= 31 -> PendingIntent.FLAG_MUTABLE
+                else -> 0
+            }
             return PendingIntent.getBroadcast(context, requestCode, intent, flags)
         }
     }

--- a/library/src/main/kotlin/io/beyondwords/player/MediaButtonReceiver.kt
+++ b/library/src/main/kotlin/io/beyondwords/player/MediaButtonReceiver.kt
@@ -30,7 +30,7 @@ open class MediaButtonReceiver constructor(private val mediaSessionId: Int) :
             intent.putExtra(Intent.EXTRA_KEY_EVENT, KeyEvent(KeyEvent.ACTION_DOWN, keyCode))
             intent.putExtra(EXTRA_MEDIA_SESSION_ID, mediaSessionId)
             val requestCode = mediaSessionId * 1000 + keyCode // keyCode is a 3 digit number
-            val flags = if (Build.VERSION.SDK_INT >= 31) PendingIntent.FLAG_MUTABLE else 0
+            val flags = if (Build.VERSION.SDK_INT >= 31) PendingIntent.FLAG_IMMUTABLE else 0
             return PendingIntent.getBroadcast(context, requestCode, intent, flags)
         }
     }

--- a/library/src/main/kotlin/io/beyondwords/player/MediaSession.kt
+++ b/library/src/main/kotlin/io/beyondwords/player/MediaSession.kt
@@ -408,7 +408,12 @@ class MediaSession constructor(private val webView: WebView) {
         mediaSession = MediaSessionCompat(context, "BeyondWords").apply {
             setCallback(mediaSessionCallback)
         }
-        context.registerReceiver(mediaButtonReceiver, IntentFilter(Intent.ACTION_MEDIA_BUTTON))
+        ContextCompat.registerReceiver(
+            context,
+            mediaButtonReceiver,
+            IntentFilter(Intent.ACTION_MEDIA_BUTTON),
+            ContextCompat.RECEIVER_NOT_EXPORTED
+        )
         webView.addJavascriptInterface(bridge, "MediaSessionBridge")
     }
 


### PR DESCRIPTION
Currently the library does not work with Android 14 during some security exceptions. 
See https://developer.android.com/about/versions/14/behavior-changes-14#runtime-receivers-exported.

With these small fixes the BeyondWords Library will also work with Android 14 (SDK 34).